### PR TITLE
Fix/namespacing glueops dashboards

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.8.1-alpha1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-grafana-dashboards
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.8.1-alpha1](https://img.shields.io/badge/Version-0.8.1--alpha1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 A Helm chart for Grafana Dashboards for the GlueOps Platform. Given how Helm template works whenever you have a `{{var}}` in your grafana json you need to change it so that its excplitity escaped with a backtick. ORIGINAL- {{kubernetes_pod_name}} WORKING- ```{{`{{kubernetes_pod_name}}`}}```
 

--- a/templates/argocd.yaml
+++ b/templates/argocd.yaml
@@ -6,7 +6,7 @@ metadata:
     grafana_dashboard: "1"
 data:
   #https://grafana.com/grafana/dashboards/14584-argocd/
-  argocd.json: |
+  glueops-argocd.json: |
     {
       "__inputs": [],
       "__requires": [

--- a/templates/cert-manager.yaml
+++ b/templates/cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
     grafana_dashboard: "1"
 data:
 #https://grafana.com/grafana/dashboards/11001-cert-manager/
-  cert-manager.json: |
+  glueops-cert-manager.json: |
     {
         "annotations": {
           "list": [

--- a/templates/debezium-generic.yaml
+++ b/templates/debezium-generic.yaml
@@ -6,7 +6,7 @@ metadata:
     grafana_dashboard: "1"
 data:
 # https://raw.githubusercontent.com/debezium/debezium-examples/main/monitoring/debezium-grafana/debezium-dashboard.json
-  debezium-generic.json: |
+  glueops-debezium-generic.json: |
     {
       "annotations": {
         "list": [

--- a/templates/external-dns.yaml
+++ b/templates/external-dns.yaml
@@ -6,7 +6,7 @@ metadata:
     grafana_dashboard: "1"
 data:
 #https://grafana.com/grafana/dashboards/15038-external-dns/
-  external-dns.json: |
+  glueops-external-dns.json: |
     {
         "annotations": {
           "list": [

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
 #https://grafana.com/grafana/dashboards/12559-grafana-loki-dashboard-for-nginx-service-mesh/
 #https://grafana.com/grafana/dashboards/13865-fgc-nginx01-web-analytics/
-  ingress-by-host.json: |
+  glueops-ingress-by-host.json: |
     {
       "annotations": {
         "list": [

--- a/templates/kafka-topics.yaml
+++ b/templates/kafka-topics.yaml
@@ -6,7 +6,7 @@ metadata:
     grafana_dashboard: "1"
 data:
 #https://grafana.com/grafana/dashboards/10122-kafka-topics/
-  kafka-topics.json: |
+  glueops-kafka-topics.json: |
     {
         "__inputs": [],
         "__requires": [

--- a/templates/keda.yaml
+++ b/templates/keda.yaml
@@ -6,7 +6,7 @@ metadata:
     grafana_dashboard: "1"
 data:
 #https://github.com/kedacore/keda/blob/main/config/grafana/keda-dashboard.json
-  keda.json: |
+  glueops-keda.json: |
     {
       "annotations": {
         "list": [

--- a/templates/loki-logs.yaml
+++ b/templates/loki-logs.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     grafana_dashboard: "1"
 data:
-  loki-logs.json: |
+  glueops-loki-logs.json: |
     {
       "annotations": {
         "list": [

--- a/templates/nginx-ingress.yaml
+++ b/templates/nginx-ingress.yaml
@@ -6,7 +6,7 @@ metadata:
     grafana_dashboard: "1"
 data:
 #https://grafana.com/grafana/dashboards/15038-external-dns/
-  nginx-ingress.json: |
+  glueops-nginx-ingress.json: |
     {
       "annotations": {
         "list": [

--- a/templates/strimzi-kafka-exporter.yaml
+++ b/templates/strimzi-kafka-exporter.yaml
@@ -6,7 +6,7 @@ metadata:
     grafana_dashboard: "1"
 data:
 #https://grafana.com/grafana/dashboards/11285-strimzi-kafka-exporter/
-  strimzi-kafka-exporter.json: |
+  glueops-strimzi-kafka-exporter.json: |
     {
         "annotations": {
           "list": [

--- a/templates/strimzi-kafka.yaml
+++ b/templates/strimzi-kafka.yaml
@@ -6,7 +6,7 @@ metadata:
     grafana_dashboard: "1"
 data:
 #https://grafana.com/grafana/dashboards/11271-strimzi-kafka/
-  strimzi-kafka.json: |
+  glueops-strimzi-kafka.json: |
     {
       "annotations": {
         "list": [

--- a/templates/vault.yaml
+++ b/templates/vault.yaml
@@ -6,7 +6,7 @@ metadata:
     grafana_dashboard: "1"
 data:
 #https://grafana.com/grafana/dashboards/12904-hashicorp-vault/
-  vault.json: |
+  glueops-vault.json: |
     {
       "annotations": {
         "list": [


### PR DESCRIPTION
it appears the newer version of kube prometheus stack has a conflicting name of loki-logs.json so I prefixed all of our dashboard file names with glueops-