### PR TITLE
feat: renaming chart for loki-logs

### DIFF
--- a/templates/loki-logs.yaml
+++ b/templates/loki-logs.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: grafana-dashboard-loki-logs
+  name: grafana-dashboard-loki-workload-logs
   labels:
     grafana_dashboard: "1"
 data:
-  glueops-loki-logs.json: |
+  glueops-workload-logs.json: |
     {
       "annotations": {
         "list": [
@@ -133,7 +133,7 @@ data:
       },
       "timepicker": {},
       "timezone": "",
-      "title": "Loki - Logs",
+      "title": "Loki - Workload Logs",
       "uid": "tBmi6B0Vz",
       "version": 9,
       "weekStart": ""


### PR DESCRIPTION
seems like the built in loki chart named: "Loki / Logs" is conflicting with ours "Loki - Logs". It's likely they convert slashes to dashes and it's causing a collision